### PR TITLE
Add minimal React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,24 @@ Example endpoints:
 - `POST /plan` – generate an adaptive plan based on the registered project
 
 Both services will be available locally at `http://localhost:<port>` once started.
+
+## Frontend (React + Vite)
+
+A lightweight React interface is provided in the `frontend/` directory. It allows creating memory entries and viewing the most recent stored items.
+
+### Setup
+
+Install Node dependencies:
+
+```bash
+cd frontend
+npm install
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` and assumes the backend memory API is running on `http://localhost:8001`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Oculus Dei</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "oculus-dei-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.0.2",
+    "vite": "^4.3.2"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import MemoryForm from './components/MemoryForm';
+import MemoryList from './components/MemoryList';
+
+const App: React.FC = () => {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Oculus Dei Memory</h1>
+      <MemoryForm />
+      <MemoryList />
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/MemoryForm.tsx
+++ b/frontend/src/components/MemoryForm.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+const MEMORY_TYPES = ['event', 'decision', 'insight', 'project'];
+
+const MemoryForm: React.FC = () => {
+  const [type, setType] = useState('event');
+  const [content, setContent] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content) return;
+
+    const res = await fetch('http://localhost:8001/memory/manual', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, content, metadata: {} })
+    });
+
+    if (res.ok) {
+      setContent('');
+      setMessage('Memory stored');
+    } else {
+      setMessage('Failed to store');
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="bg-white p-4 rounded shadow mb-4">
+      <div className="flex items-center mb-2">
+        <label className="mr-2">Type:</label>
+        <select
+          value={type}
+          onChange={e => setType(e.target.value)}
+          className="border rounded p-1"
+        >
+          {MEMORY_TYPES.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-2">
+        <textarea
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          className="border rounded w-full p-2"
+          rows={3}
+          placeholder="Memory content"
+        />
+      </div>
+      <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded">Save</button>
+      {message && <p className="text-sm mt-2">{message}</p>}
+    </form>
+  );
+};
+
+export default MemoryForm;

--- a/frontend/src/components/MemoryList.tsx
+++ b/frontend/src/components/MemoryList.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+
+interface MemoryEntry {
+  id: string;
+  timestamp: string;
+  type: string;
+  content: string;
+}
+
+const MemoryList: React.FC = () => {
+  const [entries, setEntries] = useState<MemoryEntry[]>([]);
+
+  const fetchEntries = async () => {
+    const res = await fetch('http://localhost:8001/memory/last?n=10');
+    if (res.ok) {
+      const data = await res.json();
+      setEntries(data.entries || []);
+    }
+  };
+
+  useEffect(() => {
+    fetchEntries();
+  }, []);
+
+  return (
+    <div className="bg-white p-4 rounded shadow">
+      <h2 className="text-lg font-semibold mb-2">Recent Memories</h2>
+      <ul>
+        {entries.map(entry => (
+          <li key={entry.id} className="border-b py-2">
+            <div className="text-sm text-gray-600">{entry.timestamp} — {entry.type}</div>
+            <div>{entry.content}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MemoryList;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add new `frontend` folder with a Vite + React + Tailwind setup
- implement `MemoryForm` and `MemoryList` components
- show how to start the frontend in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm --version`
