### PR TITLE
Improve memory API and store

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ uvicorn backend.api.memory_api:app --reload --port 8001
 Example endpoints:
 
 - `GET /memory/last` – retrieve the most recent entries
+- `GET /memory/id/{entry_id}` – retrieve a specific entry by ID
 - `POST /memory/manual` – create a new memory entry
 
 ### Adaptive Plan API

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,26 @@
+import unittest
+from backend.memory.memory_writer import get_memory_store, log_event
+
+class MemoryStoreTest(unittest.TestCase):
+    def setUp(self):
+        self.store = get_memory_store()
+        self.store.clear()
+
+    def tearDown(self):
+        self.store.clear()
+
+    def test_store_and_get_by_id(self):
+        entry_id = log_event("test event", {})
+        entry = self.store.get_by_id(entry_id)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.content, "test event")
+
+    def test_get_last(self):
+        log_event("first")
+        log_event("second")
+        entries = self.store.get_last(1)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].content, "second")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `MemoryStore` thread-safe using an RLock
- add entry type validation and new `/memory/id/{entry_id}` endpoint
- document new endpoint in README
- cover `MemoryStore` with simple unittests

## Testing
- `python -m unittest discover -s tests -v`
