### PR TITLE
feat(memory): hashed embedding semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example endpoints:
 - `GET /memory/id/{entry_id}` – retrieve a specific entry by ID
 - `DELETE /memory/id/{entry_id}` – delete an entry by ID
 - `POST /memory/manual` – create a new memory entry
+- `GET /memory/semantic` – semantic search using hashed embeddings
 
 ### Adaptive Plan API
 

--- a/backend/api/memory_api.py
+++ b/backend/api/memory_api.py
@@ -24,6 +24,7 @@ from backend.memory.memory_writer import (
 )
 from backend.memory.memory_retriever import (
     find_entries_by_keyword,
+    semantic_search,
     summarize_recent_events,
     count_entries_by_type,
 )
@@ -234,10 +235,30 @@ async def search_entries(
         MemoryListResponse with the matching entries
     """
     entries = find_entries_by_keyword(q, type_filter)
-    
+
     return MemoryListResponse(
         total=len(entries),
         entries=[memory_entry_to_response(entry) for entry in entries]
+    )
+
+
+@app.get(
+    "/memory/semantic",
+    response_model=MemoryListResponse,
+    tags=["Memory Retrieval"],
+    summary="Semantic search of memory entries",
+    description="Retrieve entries most similar to the provided text using hashed embeddings",
+)
+async def semantic_search_entries(
+    q: str = Query(..., min_length=2, description="Query text for semantic search"),
+    n: int = Query(5, ge=1, le=50, description="Number of entries to return"),
+    type_filter: Optional[str] = Query(None, description="Optional type filter"),
+):
+    """Return entries semantically similar to the query text."""
+    entries = semantic_search(q, top_n=n, type_filter=type_filter)
+    return MemoryListResponse(
+        total=len(entries),
+        entries=[memory_entry_to_response(entry) for entry in entries],
     )
 
 

--- a/backend/memory/memory_retriever.py
+++ b/backend/memory/memory_retriever.py
@@ -57,6 +57,18 @@ def find_entries_by_keyword(keyword: str, type_filter: Optional[str] = None) -> 
     return matching_entries
 
 
+def semantic_search(query: str, top_n: int = 5, type_filter: Optional[str] = None) -> List[MemoryEntry]:
+    """Search memory entries semantically using hashed embeddings."""
+    if not query:
+        return []
+
+    memory_store = get_memory_store()
+    results = memory_store.search_by_similarity(query, top_n)
+    if type_filter:
+        results = [entry for entry in results if entry.type == type_filter]
+    return results
+
+
 def get_related_entries(metadata_key: str, metadata_value: Any) -> List[MemoryEntry]:
     """
     Retrieve memory entries that have a specific metadata key-value pair.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,7 @@ The foundation of the system that stores, retrieves, and analyzes experiences, a
 - **Responsibilities**:
   - Storing structured memory entries (events, decisions, insights) with rich metadata
   - Providing efficient retrieval by type, keyword, temporality, and metadata
+  - Offering lightweight semantic search via hashed vector embeddings for better context matching
   - Supporting analytical queries for reflection and pattern recognition
   - Maintaining the system's episodic history and experiential context
 

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,6 +1,9 @@
 import unittest
 from backend.memory.memory_writer import get_memory_store, log_event
 from backend.memory.memory_writer import delete_entry
+from backend.memory.memory_store import MemoryEntry
+from backend.memory.memory_store import MemoryStore
+
 
 class MemoryStoreTest(unittest.TestCase):
     def setUp(self):
@@ -28,6 +31,19 @@ class MemoryStoreTest(unittest.TestCase):
         deleted = delete_entry(entry_id)
         self.assertTrue(deleted)
         self.assertIsNone(self.store.get_by_id(entry_id))
+
+    def test_semantic_search(self):
+        self.store.clear()
+        id_ml = log_event("Started machine learning project")
+        log_event("Went grocery shopping")
+
+        results = self.store.search_by_similarity("ML project", top_n=1)
+        self.assertEqual(results[0].id, id_ml)
+
+    def test_store_rejects_empty_content(self):
+        entry = MemoryEntry(type="event", content="", metadata={})
+        with self.assertRaises(ValueError):
+            self.store.store(entry)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `MemoryStore` with hashed embeddings and cosine similarity
- expose new `/memory/semantic` endpoint
- add `semantic_search` helper
- document semantic search capability
- test semantic search and edge cases

## Testing
- `python -m unittest discover -s tests`