### PR TITLE
Add local dev script with auto pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,15 @@ npm run dev
 ```
 
 The app will be available at `http://localhost:5173` and assumes the backend memory API is running on `http://localhost:8001`.
+
+## Combined Local Development
+
+To run both the FastAPI backend on port `8000` and the React frontend on port `5173`
+with automatic updates from `origin/main`, use the `dev.sh` script:
+
+```bash
+./dev.sh
+```
+
+The script pulls the latest changes every 10 seconds and leverages `uvicorn` and
+`vite` for hot reloading. Press `Ctrl+C` to stop all processes.

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+set -e
+
+# Start auto-pulling latest changes from origin/main every 10 seconds
+(
+  while true; do
+    git pull --ff-only origin main >/dev/null 2>&1 || echo "git pull failed"
+    sleep 10
+  done
+) &
+PULL_PID=$!
+
+# Start backend with hot reload
+uvicorn backend.api.adaptive_plan_api:app --reload --port 8000 &
+BACKEND_PID=$!
+
+# Start frontend development server
+npm --prefix frontend run dev -- --port 5173 &
+FRONTEND_PID=$!
+
+# Ensure child processes are terminated on exit
+trap "kill $PULL_PID $BACKEND_PID $FRONTEND_PID" INT TERM EXIT
+
+# Wait for backend and frontend to exit
+wait $BACKEND_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- add `dev.sh` script to run backend and frontend concurrently with hot reload and frequent `git pull`
- document unified local dev workflow in README

## Testing
- `python3 -m unittest discover -s tests`
