### PR TITLE
Add reflection API and memory updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the backend components for the **Oculus Dei** life mana
 - `backend/api/` – REST services built with FastAPI
   - `memory_api.py` – access to the memory store
   - `adaptive_plan_api.py` – register projects and generate adaptive plans
+  - `reflector_api.py` – trigger reflection cycles
 - `backend/memory/` – in-memory storage and retrieval utilities
 - `backend/core/` – project registry and life optimizer modules
 - `backend/agent/` – presence controller used by the optimizer
@@ -70,6 +71,18 @@ Example endpoints:
 - `POST /plan` – generate an adaptive plan based on the registered project
 
 Both services will be available locally at `http://localhost:<port>` once started.
+
+### Reflector API
+
+Run the reflection service on port `8002`:
+
+```bash
+python backend/api/reflector_api.py
+```
+
+Key endpoint:
+
+- `POST /reflect` – trigger a reflection cycle and return the prompt
 
 ## Frontend (React + Vite)
 

--- a/backend/api/memory_api.py
+++ b/backend/api/memory_api.py
@@ -67,6 +67,8 @@ class MemoryCreateRequest(BaseModel):
         insight = "insight"
         project = "project"
         error = "error"
+        reflection = "reflection"
+        interaction = "interaction"
 
     type: EntryType = Field(..., description="Type of memory entry")
     content: str = Field(..., description="Content of the memory entry")

--- a/backend/api/reflector_api.py
+++ b/backend/api/reflector_api.py
@@ -1,0 +1,40 @@
+"""FastAPI endpoints for triggering memory reflections."""
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from backend.memory.reflector_scheduler import run_reflection_cycle
+
+app = FastAPI(
+    title="Oculus Dei Reflector API",
+    description="Trigger and inspect memory reflections",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class ReflectionResponse(BaseModel):
+    status: str
+    prompt: str | None = None
+
+@app.post("/reflect", response_model=ReflectionResponse, tags=["Reflection"])
+async def trigger_reflection(force: bool = True) -> ReflectionResponse:
+    """Trigger a reflection cycle and return the generated prompt."""
+    try:
+        prompt = run_reflection_cycle(force=force)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if not prompt:
+        return ReflectionResponse(status="no_insight", prompt=None)
+    return ReflectionResponse(status="success", prompt=prompt)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/backend/memory/memory_store.py
+++ b/backend/memory/memory_store.py
@@ -132,6 +132,11 @@ class MemoryStore:
         """
         with self._lock:
             return list(self.type_index.get(entry_type, []))
+
+    def get_all(self) -> List[MemoryEntry]:
+        """Return all entries sorted chronologically (newest first)."""
+        with self._lock:
+            return sorted(self.entries, key=lambda e: e.timestamp, reverse=True)
     
     def search_by_text(self, keyword: str) -> List[MemoryEntry]:
         """

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ The system aims to provide a unified framework for managing life's complexity by
                                     ▼
 ┌───────────────────────────────────────────────────────────────┐
 │                           API LAYER                            │
-│     adaptive_plan_api.py           memory_api.py               │
+│     adaptive_plan_api.py  memory_api.py  reflector_api.py      │
 └───────────────────────────────────┬───────────────────────────┘
                                     │
           ┌─────────────────────────┼─────────────────────────┐
@@ -69,7 +69,8 @@ backend/
 │   └── presence_controller.py  # Coordinates life restructuring responses
 ├── api/
 │   ├── adaptive_plan_api.py    # REST API for projects and adaptive plans
-│   └── memory_api.py           # REST API for memory access
+│   ├── memory_api.py           # REST API for memory access
+│   └── reflector_api.py        # Trigger reflection cycles
 ├── core/
 │   ├── project_registry.py     # Registers projects and analyzes impact
 │   └── life_optimizer.py       # Transforms impacts into actionable plans
@@ -135,7 +136,7 @@ Coordinates responses to external events and internal triggers, serving as the e
 
 Exposes system functionality to external interfaces, acting as the communication bridge to users and other systems.
 
-- **Components**: `adaptive_plan_api.py`, `memory_api.py`
+- **Components**: `adaptive_plan_api.py`, `memory_api.py`, `reflector_api.py`
 - **Responsibilities**:
   - Providing REST endpoints for UI and external systems with clear contracts
   - Handling data serialization and validation with strong typing


### PR DESCRIPTION
## Summary
- add `/reflect` endpoint in new `reflector_api` for triggering reflection cycles
- extend memory API to support `reflection` and `interaction` entry types
- expose `get_all` helper in `MemoryStore`
- document reflector API in README and architecture docs

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*