### PR TITLE
Add AI assistant proxy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the backend components for the **Oculus Dei** life mana
   - `memory_api.py` – access to the memory store
   - `adaptive_plan_api.py` – register projects and generate adaptive plans
   - `reflector_api.py` – trigger reflection cycles
+  - `assistant_api.py` – proxy requests to OpenAI or Anthropic
 - `backend/memory/` – in-memory storage and retrieval utilities
 - `backend/core/` – project registry and life optimizer modules
 - `backend/agent/` – presence controller used by the optimizer
@@ -84,6 +85,20 @@ Key endpoint:
 
 - `POST /reflect` – trigger a reflection cycle and return the prompt
 
+### Assistant Proxy API
+
+Proxy service on port `8003` that forwards prompts to either OpenAI or
+Anthropic based on provided API keys.
+
+```bash
+python backend/api/assistant_api.py
+```
+
+Environment variables used if keys are not supplied in the request:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
 ## Frontend (React + Vite)
 
 A lightweight React interface is provided in the `frontend/` directory. It allows creating memory entries, viewing recent items, and now includes a simple visualization of memory types with optional dark mode support.
@@ -107,8 +122,9 @@ The app will be available at `http://localhost:5173` and assumes the backend mem
 
 ## Combined Local Development
 
-To run both the FastAPI backend on port `8000` and the React frontend on port `5173`
-with automatic updates from `origin/main`, use the `dev.sh` script:
+To run all backend services (adaptive plan, memory store and assistant proxy)
+alongside the React frontend with automatic updates from `origin/main`, use the
+`dev.sh` script:
 
 ```bash
 ./dev.sh

--- a/backend/api/assistant_api.py
+++ b/backend/api/assistant_api.py
@@ -1,0 +1,118 @@
+"""AI Assistant Proxy API."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+from urllib import request
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+
+class AIRequest(BaseModel):
+    """Request body for the AI proxy."""
+
+    model: Optional[str] = "gpt-3.5-turbo"
+    prompt: Optional[str] = None
+    message: Optional[str] = None
+    temperature: float = 0.7
+    max_tokens: int = 256
+    openai_key: Optional[str] = None
+    anthropic_key: Optional[str] = None
+    mode: Optional[str] = None
+
+
+app = FastAPI(
+    title="Assistant Proxy API",
+    description="Simple proxy to OpenAI or Anthropic APIs",
+    version="0.1.0",
+)
+
+
+def _call_openai(payload: AIRequest, api_key: str) -> str:
+    """Send the prompt to OpenAI and return the response text."""
+
+    body = json.dumps(
+        {
+            "model": payload.model,
+            "messages": [{"role": "user", "content": payload.prompt}],
+            "temperature": payload.temperature,
+            "max_tokens": payload.max_tokens,
+        }
+    ).encode()
+
+    req = request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+
+    with request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+    return data["choices"][0]["message"]["content"]
+
+
+def _call_anthropic(payload: AIRequest, api_key: str) -> str:
+    """Send the prompt to Anthropic and return the response text."""
+
+    body = json.dumps(
+        {
+            "model": payload.model,
+            "messages": [{"role": "user", "content": payload.prompt}],
+            "temperature": payload.temperature,
+            "max_tokens": payload.max_tokens,
+        }
+    ).encode()
+
+    req = request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+
+    with request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+    return data["content"][0]["text"]
+
+
+@app.post("/proxy/ai")
+async def proxy_ai(request_body: AIRequest) -> dict:
+    """Proxy incoming requests to the configured AI provider."""
+
+    prompt = request_body.prompt or request_body.message
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Prompt is required")
+
+    request_body.prompt = prompt
+
+    openai_key = request_body.openai_key or os.getenv("OPENAI_API_KEY")
+    anthropic_key = request_body.anthropic_key or os.getenv("ANTHROPIC_API_KEY")
+
+    try:
+        if anthropic_key:
+            response_text = _call_anthropic(request_body, anthropic_key)
+        else:
+            if not openai_key:
+                raise HTTPException(status_code=400, detail="OpenAI key missing")
+            response_text = _call_openai(request_body, openai_key)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return {"response": response_text}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8003)

--- a/dev.sh
+++ b/dev.sh
@@ -61,6 +61,15 @@ start_memory_api() {
   cd ..
 }
 
+# Start assistant proxy server
+start_assistant_api() {
+  echo "🔄 Starting assistant API server on port 8003..."
+  cd backend
+  source venv/bin/activate
+  python -m uvicorn api.assistant_api:app --host 0.0.0.0 --port 8003 --reload & BACK3_PID=$!
+  cd ..
+}
+
 # ── git-watch loop ────────────────────────────────────────────────────────────
 echo "🌀  git-watch loop started (PID $$)"
 (
@@ -74,10 +83,10 @@ echo "🌀  git-watch loop started (PID $$)"
       git pull --ff-only origin main
 
       # ── stop old processes ───────────────────────────────────────────────
-      kill $BACK1_PID $BACK2_PID $FRONT_PID 2>/dev/null || true
+      kill $BACK1_PID $BACK2_PID $BACK3_PID $FRONT_PID 2>/dev/null || true
 
       # жёстко освобождаем порты (vite и оба uvicorn-а)
-      for PORT in 5173 8000 8001; do
+      for PORT in 5173 8000 8001 8003; do
         if lsof -i :$PORT -t >/dev/null 2>&1; then
           lsof -ti :$PORT | xargs kill -9
         fi
@@ -86,6 +95,7 @@ echo "🌀  git-watch loop started (PID $$)"
       # restart backend + frontend
       uvicorn backend.api.adaptive_plan_api:app --reload --port 8000 & BACK1_PID=$!
       uvicorn backend.api.memory_api:app        --reload --port 8001 & BACK2_PID=$!
+      uvicorn backend.api.assistant_api:app     --reload --port 8003 & BACK3_PID=$!
       
       # ждём максимум 5 сек, пока 5173 освободится
       for i in {1..10}; do
@@ -103,19 +113,21 @@ PULL_PID=$!
 
 # Main function
 main() {
-  echo "⚙️  Oculus Dei Development Environment"
+  echo "⚙ Starting development stack"
   echo "──────────────────────────────────────"
   
   check_requirements
   
   start_backend
   start_memory_api
+  start_assistant_api
   start_frontend
   
   echo "✅ All services started!"
-  echo "   Backend: http://localhost:8000"
-  echo "   Memory API: http://localhost:8001"
-  echo "   Frontend: http://localhost:5173"
+  echo "   Backend:   http://localhost:8000"
+  echo "   Memory API:    http://localhost:8001"
+  echo "   Assistant API: http://localhost:8003"
+  echo "   Frontend:      http://localhost:5173"
   echo "   Press Ctrl+C to stop all services"
   echo "──────────────────────────────────────"
   

--- a/tests/test_assistant_api.py
+++ b/tests/test_assistant_api.py
@@ -1,0 +1,50 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from backend.api.assistant_api import app
+
+client = TestClient(app)
+
+
+class DummyResp:
+    def __init__(self, payload: str):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload.encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def fake_urlopen(req, timeout=10):
+    data = json.dumps({"choices": [{"message": {"content": "ok"}}]})
+    return DummyResp(data)
+
+
+def fake_urlopen_anthropic(req, timeout=10):
+    data = json.dumps({"content": [{"text": "a-ok"}]})
+    return DummyResp(data)
+
+
+@patch("backend.api.assistant_api.request.urlopen", side_effect=fake_urlopen)
+def test_proxy_openai(mock_urlopen):
+    resp = client.post("/proxy/ai", json={"prompt": "hi", "openai_key": "k"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "ok"}
+
+
+@patch("backend.api.assistant_api.request.urlopen", side_effect=fake_urlopen_anthropic)
+def test_proxy_anthropic(mock_urlopen):
+    resp = client.post(
+        "/proxy/ai",
+        json={"prompt": "hi", "anthropic_key": "k", "model": "claude"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "a-ok"}


### PR DESCRIPTION
## Summary
- implement assistant_api to proxy requests to OpenAI or Anthropic
- start assistant API from `dev.sh`
- document new service and keys in README
- add tests for the assistant proxy

## Testing
- `black backend/api/assistant_api.py tests/test_assistant_api.py`
- `flake8 backend tests` *(fails: command not found)*
- `mypy backend` *(fails with existing type errors)*
- `pytest -q` *(fails: command not found)*