### PR TITLE
Add AI proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ npm run dev
 ```
 
 The app will be available at `http://localhost:5173` and assumes the backend memory API is running on `http://localhost:8001`.
+Requests to `/proxy/ai` are automatically forwarded to `http://localhost:8003` via Vite's proxy configuration.
 
 ## Combined Local Development
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/proxy/ai': 'http://localhost:8003'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/proxy/ai` to `http://localhost:8003`
- document the proxy under the frontend setup section

## Testing
- `black --check .` *(fails: would reformat 14 files)*
- `mypy backend` *(fails: found 13 errors)*
- `pytest -q` *(fails: command not found)*
- `flake8 backend` *(fails: command not found)*