### PR TITLE
Use .env values in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ frontend/node_modules/.vite/
 # Python
 __pycache__/
 *.py[cod]
+# Environment files
+.env
+frontend/.env

--- a/README.md
+++ b/README.md
@@ -105,10 +105,16 @@ A lightweight React interface is provided in the `frontend/` directory. It allow
 
 ### Setup
 
-Install Node dependencies:
+Copy the example environment file and adjust the API endpoints if needed:
 
 ```bash
 cd frontend
+cp .env.example .env
+```
+
+Install Node dependencies:
+
+```bash
 npm install
 ```
 
@@ -118,7 +124,7 @@ Start the development server:
 npm run dev
 ```
 
-The app will be available at `http://localhost:5173` and assumes the backend memory API is running on `http://localhost:8001`.
+The app will be available at `http://localhost:5173`. Backend service URLs are configured via `VITE_MEMORY_API_URL` and `VITE_PLAN_API_URL` in `.env`.
 
 ## Combined Local Development
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_MEMORY_API_URL=http://localhost:8001
+VITE_PLAN_API_URL=http://localhost:8000

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,10 +1,14 @@
 import axios from 'axios';
 
 /** Base Axios instance for the memory service */
-const memoryApi = axios.create({ baseURL: 'http://localhost:8001' });
+const memoryApi = axios.create({
+  baseURL: import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001'
+});
 
 /** Base Axios instance for the planning/project service */
-const projectApi = axios.create({ baseURL: 'http://localhost:8000' });
+const projectApi = axios.create({
+  baseURL: import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000'
+});
 
 export interface MemoryEntry {
   id: string;

--- a/frontend/src/components/Chat/EnhancedChatInterface.tsx
+++ b/frontend/src/components/Chat/EnhancedChatInterface.tsx
@@ -9,7 +9,8 @@ interface DialogSettings {
   anthropicKey: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const defaultSettings: DialogSettings = {
   model: 'gpt-4o',

--- a/frontend/src/components/Layout/AppSidebar.tsx
+++ b/frontend/src/components/Layout/AppSidebar.tsx
@@ -14,8 +14,9 @@ interface GoalEntry {
   timestamp: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
-const PLAN_API = 'http://localhost:8000';
+const MEMORY_API =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
+const PLAN_API = import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000';
 
 const AppSidebar: React.FC = () => {
   const [projects, setProjects] = useState<ProjectSummary[]>([]);

--- a/frontend/src/components/Visualizations/MemoryChart.tsx
+++ b/frontend/src/components/Visualizations/MemoryChart.tsx
@@ -6,7 +6,8 @@ interface ChartData {
   color: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const MemoryChart: React.FC = () => {
   const [chartData, setChartData] = useState<ChartData[]>([]);

--- a/frontend/src/context/MemoryContext.tsx
+++ b/frontend/src/context/MemoryContext.tsx
@@ -24,7 +24,8 @@ interface MemoryContextType {
   getEntriesByType: (type: string) => Promise<MemoryEntry[]>;
 }
 
-const API_BASE_URL = 'http://localhost:8001';
+const API_BASE_URL =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const MemoryContext = React.createContext<MemoryContextType | undefined>(undefined);
 

--- a/frontend/src/views/AIAssistantDialog.tsx
+++ b/frontend/src/views/AIAssistantDialog.tsx
@@ -24,7 +24,8 @@ interface DialogSettings {
   anthropicKey: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const defaultSettings: DialogSettings = {
   model: 'gpt-4o',

--- a/frontend/src/views/LifeCommandCenter.tsx
+++ b/frontend/src/views/LifeCommandCenter.tsx
@@ -18,10 +18,15 @@ interface ApiStatusData {
   endpoint: string;
 }
 
+const MEMORY_API =
+  import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
+const PLAN_API =
+  import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000';
+
 const LifeCommandCenter: React.FC = () => {
   const [systemStatus, setSystemStatus] = useState<ApiStatusData[]>([
-    { name: 'Memory API', status: 'active', endpoint: 'http://localhost:8001' },
-    { name: 'Plan API', status: 'active', endpoint: 'http://localhost:8000' },
+    { name: 'Memory API', status: 'active', endpoint: MEMORY_API },
+    { name: 'Plan API', status: 'active', endpoint: PLAN_API },
     { name: 'Reflection System', status: 'processing', endpoint: '' }
   ]);
   


### PR DESCRIPTION
## Summary
- support `VITE_MEMORY_API_URL` and `VITE_PLAN_API_URL` in React code
- provide `.env.example` for the frontend
- ignore local `.env` files
- document frontend environment setup

## Testing
- `pytest -q` *(fails: command not found)*