### PR TITLE
Add frontend tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Run tests
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Run tests
+        run: |
+          cd frontend
+          npm test -- --run

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.6.0",
@@ -23,6 +24,11 @@
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
-    "vite": "^4.3.2"
+    "vite": "^4.3.2",
+    "vitest": "^0.34.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^22.1.0"
   }
 }

--- a/frontend/src/components/Chat/EnhancedChatInterface.test.tsx
+++ b/frontend/src/components/Chat/EnhancedChatInterface.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import EnhancedChatInterface from './EnhancedChatInterface';
+
+const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+  if (typeof input === 'string' && input === '/proxy/ai') {
+    return Promise.resolve({ json: () => Promise.resolve({ message: 'hi there' }) }) as any;
+  }
+  return Promise.resolve({ json: () => Promise.resolve({}) }) as any;
+});
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('sends message and displays reply', async () => {
+  render(<EnhancedChatInterface />);
+  await userEvent.type(screen.getByPlaceholderText(/type your message/i), 'hello');
+  const buttons = screen.getAllByRole('button');
+  const sendButton = buttons[buttons.length - 1];
+  await userEvent.click(sendButton);
+  expect(fetchMock).toHaveBeenCalledWith('/proxy/ai', expect.anything());
+  await screen.findByText('hello');
+  await screen.findByText('hi there');
+});

--- a/frontend/src/components/__tests__/MemoryForm.test.tsx
+++ b/frontend/src/components/__tests__/MemoryForm.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import MemoryForm from '../MemoryForm';
+
+const addEntryMock = vi.fn(() => Promise.resolve());
+vi.mock('../../context/MemoryContext', () => ({
+  useMemory: () => ({ addEntry: addEntryMock })
+}));
+
+test('saves data and calls addEntry', async () => {
+  render(<MemoryForm />);
+  const textarea = screen.getByLabelText(/content/i);
+  await userEvent.type(textarea, 'test memory');
+  await userEvent.click(screen.getByRole('button', { name: /save memory/i }));
+  expect(addEntryMock).toHaveBeenCalledWith({ type: 'event', content: 'test memory', metadata: {} });
+  await screen.findByText(/memory successfully stored/i);
+});

--- a/frontend/src/components/__tests__/MemoryList.test.tsx
+++ b/frontend/src/components/__tests__/MemoryList.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import MemoryList from '../MemoryList';
+
+const entries = [
+  { id: '1', type: 'event', content: 'went to park', timestamp: '2024-01-01T00:00:00Z', metadata: {} },
+  { id: '2', type: 'decision', content: 'buy milk', timestamp: '2024-01-02T00:00:00Z', metadata: {} }
+];
+
+vi.mock('../../context/MemoryContext', () => ({
+  useMemory: () => ({ entries, refresh: vi.fn() })
+}));
+
+test('filters by type and searches', async () => {
+  render(<MemoryList />);
+  // filter by 'event'
+  await userEvent.click(screen.getByRole('button', { name: /event/i }));
+  expect(screen.getByText('went to park')).toBeInTheDocument();
+  expect(screen.queryByText('buy milk')).toBeNull();
+
+  // clear filter
+  await userEvent.click(screen.getByRole('button', { name: /event/i }));
+
+  // search for 'milk'
+  await userEvent.type(screen.getByPlaceholderText(/search memories/i), 'milk');
+  expect(screen.getByText('buy milk')).toBeInTheDocument();
+  expect(screen.queryByText('went to park')).toBeNull();
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts'
   }
 });


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library setup
- write tests for MemoryForm, MemoryList and EnhancedChatInterface
- configure Vitest in vite.config
- run tests in CI workflow along with backend tests

## Testing
- `npm test -- -t none` *(fails: vitest not found)*
- `pip install -r backend/requirements.txt` *(fails: no route to host)*