### PR TITLE
Use env vars for API URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ frontend/node_modules/.vite/
 # Python
 __pycache__/
 *.py[cod]
+
+# Environment files
+frontend/.env
+

--- a/README.md
+++ b/README.md
@@ -112,13 +112,22 @@ cd frontend
 npm install
 ```
 
+Copy the example environment file and update values if needed:
+
+```bash
+cp frontend/.env.example frontend/.env
+# Edit frontend/.env to match your backend URLs
+```
+
 Start the development server:
 
 ```bash
 npm run dev
 ```
 
-The app will be available at `http://localhost:5173` and assumes the backend memory API is running on `http://localhost:8001`.
+The app will be available at `http://localhost:5173`.
+Backend endpoints are configured via `frontend/.env` using
+`VITE_MEMORY_API_URL` and `VITE_PLAN_API_URL`.
 
 ## Combined Local Development
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_MEMORY_API_URL=http://localhost:8001
+VITE_PLAN_API_URL=http://localhost:8000

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,10 +1,14 @@
 import axios from 'axios';
 
 /** Base Axios instance for the memory service */
-const memoryApi = axios.create({ baseURL: 'http://localhost:8001' });
+const memoryApi = axios.create({
+  baseURL: import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001'
+});
 
 /** Base Axios instance for the planning/project service */
-const projectApi = axios.create({ baseURL: 'http://localhost:8000' });
+const projectApi = axios.create({
+  baseURL: import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000'
+});
 
 export interface MemoryEntry {
   id: string;

--- a/frontend/src/components/Chat/EnhancedChatInterface.tsx
+++ b/frontend/src/components/Chat/EnhancedChatInterface.tsx
@@ -9,7 +9,7 @@ interface DialogSettings {
   anthropicKey: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const defaultSettings: DialogSettings = {
   model: 'gpt-4o',

--- a/frontend/src/components/Layout/AppSidebar.tsx
+++ b/frontend/src/components/Layout/AppSidebar.tsx
@@ -14,8 +14,8 @@ interface GoalEntry {
   timestamp: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
-const PLAN_API = 'http://localhost:8000';
+const MEMORY_API = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
+const PLAN_API = import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000';
 
 const AppSidebar: React.FC = () => {
   const [projects, setProjects] = useState<ProjectSummary[]>([]);

--- a/frontend/src/components/Visualizations/MemoryChart.tsx
+++ b/frontend/src/components/Visualizations/MemoryChart.tsx
@@ -6,7 +6,7 @@ interface ChartData {
   color: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const MemoryChart: React.FC = () => {
   const [chartData, setChartData] = useState<ChartData[]>([]);

--- a/frontend/src/context/MemoryContext.tsx
+++ b/frontend/src/context/MemoryContext.tsx
@@ -24,7 +24,7 @@ interface MemoryContextType {
   getEntriesByType: (type: string) => Promise<MemoryEntry[]>;
 }
 
-const API_BASE_URL = 'http://localhost:8001';
+const API_BASE_URL = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const MemoryContext = React.createContext<MemoryContextType | undefined>(undefined);
 

--- a/frontend/src/views/AIAssistantDialog.tsx
+++ b/frontend/src/views/AIAssistantDialog.tsx
@@ -24,7 +24,7 @@ interface DialogSettings {
   anthropicKey: string;
 }
 
-const MEMORY_API = 'http://localhost:8001';
+const MEMORY_API = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
 
 const defaultSettings: DialogSettings = {
   model: 'gpt-4o',

--- a/frontend/src/views/LifeCommandCenter.tsx
+++ b/frontend/src/views/LifeCommandCenter.tsx
@@ -19,9 +19,12 @@ interface ApiStatusData {
 }
 
 const LifeCommandCenter: React.FC = () => {
+  const memoryUrl = import.meta.env.VITE_MEMORY_API_URL || 'http://localhost:8001';
+  const planUrl = import.meta.env.VITE_PLAN_API_URL || 'http://localhost:8000';
+
   const [systemStatus, setSystemStatus] = useState<ApiStatusData[]>([
-    { name: 'Memory API', status: 'active', endpoint: 'http://localhost:8001' },
-    { name: 'Plan API', status: 'active', endpoint: 'http://localhost:8000' },
+    { name: 'Memory API', status: 'active', endpoint: memoryUrl },
+    { name: 'Plan API', status: 'active', endpoint: planUrl },
     { name: 'Reflection System', status: 'processing', endpoint: '' }
   ]);
   


### PR DESCRIPTION
## Summary
- support `.env` variables `VITE_MEMORY_API_URL` and `VITE_PLAN_API_URL`
- replace hard-coded URLs with `import.meta.env` usage
- document how to copy `.env.example`
- add `.env` to gitignore

## Testing
- `black backend tests`
- `python -m mypy backend` *(fails: 13 errors)*
- `python -m flake8 backend tests` *(failed: flake8 not installed)*
- `python -m pytest` *(failed: pytest not installed)*